### PR TITLE
Fix amusement park's Form component not displaying in storybook

### DIFF
--- a/frontend/src/stories/components/AmusementParks/amusementParksForm.stories.js
+++ b/frontend/src/stories/components/AmusementParks/amusementParksForm.stories.js
@@ -9,7 +9,7 @@ export default {
 
 const Template = (args) => {
     return (
-        <amusementParksForm {...args} />
+        <AmusementParksForm {...args} />
     )
 };
 
@@ -23,7 +23,7 @@ Default.args = {
 export const Show = Template.bind({});
 
 Show.args = {
-    amusemenPark: amusementParksFixtures.oneAmusementPark,
+    AmusementPark: amusementParksFixtures.oneAmusementPark,
     submitText: "",
     submitAction: () => { }
 };


### PR DESCRIPTION
This PR should allow for the Form to display in the storybook now, but it doesn't fully resolve the underlying issue of inconsistent capitalization in the Form-related files. For the time being, everything at least seems to work, so I hope that's good enough.